### PR TITLE
Fix out of proc PSW support in AKS cluster

### DIFF
--- a/AKS-Deployment.md
+++ b/AKS-Deployment.md
@@ -95,7 +95,7 @@ MYAKS=aks-acc-test
 az group create --name $MYAKS-rg --location eastus
 
 # Create the cluster with a one-node non-ACC system node pool.
-az aks create --resource-group $MYAKS-rg --name $MYAKS --attach-acr $MYACR --vm-set-type VirtualMachineScaleSets --node-count 1 --node-vm-size Standard_DS2_v2 --aks-custom-headers usegen2vm=true
+az aks create --resource-group $MYAKS-rg --name $MYAKS --attach-acr $MYACR --vm-set-type VirtualMachineScaleSets --node-count 1 --enable-addon confcom --node-vm-size Standard_DS2_v2 --aks-custom-headers usegen2vm=true
 
 # Add the ACC user node pool.
 az aks nodepool add --resource-group $MYAKS-rg --cluster-name $MYAKS --name accpool --mode User --node-count 1 --node-vm-size Standard_DC4s_v2 --aks-custom-headers usegen2vm=true
@@ -105,12 +105,13 @@ az aks nodepool show -g $MYAKS-rg --cluster-name $MYAKS -n nodepool1
 az aks nodepool show -g $MYAKS-rg --cluster-name $MYAKS -n accpool
 ```
 
-Check that the SGX device plugin was deployed:
+Check that the SGX device plugin and SGX quote helper were deployed:
 ```sh
 az aks get-credentials --name $MYAKS --resource-group $MYAKS-rg
 kubectl get pods -n kube-system -l app=sgx-device-plugin
+kubectl get pods -n kube-system -l app=sgx-quote-helper
 ```
-Verify you see sgx-device-plugin-xxxxx
+Verify you see sgx-device-plugin-xxxxx and sgx-quote-helper-xxxxx
 
 If you decide to delete the AKS cluster run:
 ```sh

--- a/samples/k8s/templates/server.yaml
+++ b/samples/k8s/templates/server.yaml
@@ -28,8 +28,8 @@ spec:
       - name: model-server
         image: {{ .Values.image }}
         env:
-        #- name: SGX_AESM_ADDR
-        #  value: '1'
+        - name: SGX_AESM_ADDR
+          value: '1'
         {{- if .Values.akv }}
         - name: CONFONNX_USE_AKV
           value: '1'


### PR DESCRIPTION
Fix documentation on:
    AKS cluster setup by adding confcom addon in the command
    Adding verification on SGX quote helper needed in the confidential computing support
Uncomment out the SGX_AESM_ADDR environment variable to enable out of proc PSW support.